### PR TITLE
Atomic check for known keys

### DIFF
--- a/src/main/java/io/grpc/examples/RandomAccessSet.java
+++ b/src/main/java/io/grpc/examples/RandomAccessSet.java
@@ -1,5 +1,6 @@
 package io.grpc.examples;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -17,6 +18,11 @@ final class RandomAccessSet<T> {
     return nodeMap.isEmpty();
   }
 
+  /**
+   * Select a random key from the set.
+   * @return A key or {@code null} if the set is empty.
+   */
+  @Nullable
   T getRandomKey() {
     int nodes = nodeList.size();
     if (nodes == 0) {

--- a/src/main/java/io/grpc/examples/RandomAccessSet.java
+++ b/src/main/java/io/grpc/examples/RandomAccessSet.java
@@ -18,6 +18,10 @@ final class RandomAccessSet<T> {
   }
 
   T getRandomKey() {
+    int nodes = nodeList.size();
+    if (nodes == 0) {
+      return null;
+    }
     Random r = new Random();
     return nodeList.get(r.nextInt(nodeList.size())).value;
   }


### PR DESCRIPTION
There are two synchronized blocks: first one checks if there are any known
keys; second one retrieves a random key to operate on. The problem is
that between these two blocks collection may become empty causing
getRandomKey to fail.

Exception message looks like:
`Exception in thread "main" java.lang.IllegalArgumentException: bound must be positive
	at java.util.Random.nextInt(Random.java:388)
	at io.grpc.examples.RandomAccessSet.getRandomKey(RandomAccessSet.java:24)
	at io.grpc.examples.KvClient.doUpdate(KvClient.java:182)
	at io.grpc.examples.KvClient.doClientWork(KvClient.java:78)
	at io.grpc.examples.KvRunner.runClient(KvRunner.java:51)
	at io.grpc.examples.KvRunner.main(KvRunner.java:32)`